### PR TITLE
Handle panic error on barnybug/go-cast

### DIFF
--- a/googlehome/client.go
+++ b/googlehome/client.go
@@ -114,8 +114,8 @@ func (c *Client) GetVolume() (volume float64, err error) {
 	client := cast.NewClient(c.ip, c.port)
 	defer func() {
 		client.Close()
-		if err := recover(); err != nil {
-			err = fmt.Errorf("Panic occurs on GetVolume [%w]", err)
+		if e := recover(); e != nil {
+			err = fmt.Errorf("Panic occurs on GetVolume [%w]", e)
 		}
 	}()
 

--- a/googlehome/client.go
+++ b/googlehome/client.go
@@ -80,9 +80,15 @@ func (c *Client) Notify(text string, language ...string) error {
 }
 
 // Play make Google Home play music or sound.
-func (c *Client) Play(url string) error {
+func (c *Client) Play(url string) (e error) {
 	client := cast.NewClient(c.ip, c.port)
-	defer client.Close()
+	defer func() {
+		client.Close()
+		if err := recover(); err != nil {
+			e = fmt.Errorf("Panic occurs on Play [%w]", err)
+		}
+	}()
+
 	err := client.Connect(c.ctx)
 	if err != nil {
 		return err
@@ -106,7 +112,13 @@ func (c *Client) Play(url string) error {
 // GetVolume gets volume.
 func (c *Client) GetVolume() (volume float64, err error) {
 	client := cast.NewClient(c.ip, c.port)
-	defer client.Close()
+	defer func() {
+		client.Close()
+		if err := recover(); err != nil {
+			err = fmt.Errorf("Panic occurs on GetVolume [%w]", err)
+		}
+	}()
+
 	err = client.Connect(c.ctx)
 	if err != nil {
 		return 0, err
@@ -121,9 +133,15 @@ func (c *Client) GetVolume() (volume float64, err error) {
 }
 
 // SetVolume sets volume. volume must be 0.0 ~ 1.0.
-func (c *Client) SetVolume(volume float64) error {
+func (c *Client) SetVolume(volume float64) (e error) {
 	client := cast.NewClient(c.ip, c.port)
-	defer client.Close()
+	defer func() {
+		client.Close()
+		if err := recover(); err != nil {
+			e = fmt.Errorf("Panic occurs on SetVolume [%w]", err)
+		}
+	}()
+
 	err := client.Connect(c.ctx)
 	if err != nil {
 		return err
@@ -134,9 +152,14 @@ func (c *Client) SetVolume(volume float64) error {
 }
 
 // QuitApp stops recveiver application.
-func (c *Client) QuitApp() error {
+func (c *Client) QuitApp() (e error) {
 	client := cast.NewClient(c.ip, c.port)
-	defer client.Close()
+	defer func() {
+		client.Close()
+		if err := recover(); err != nil {
+			e = fmt.Errorf("Panic occurs on QuitApp [%w]", err)
+		}
+	}()
 
 	receiver := client.Receiver()
 	_, err := receiver.QuitApp(c.ctx)
@@ -144,9 +167,14 @@ func (c *Client) QuitApp() error {
 }
 
 // StopMedia make Google Home stop music or sound.
-func (c *Client) StopMedia() error {
+func (c *Client) StopMedia() (e error) {
 	client := cast.NewClient(c.ip, c.port)
-	defer client.Close()
+	defer func() {
+		client.Close()
+		if err := recover(); err != nil {
+			e = fmt.Errorf("Panic occurs on StopMedia [%w]", err)
+		}
+	}()
 
 	if !client.IsPlaying(c.ctx) {
 		return nil


### PR DESCRIPTION
Sometimes `barnybug/go-cast` emits panic error.
(It might be n/w conn lost.)


```bash
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc pc=0x36dae0]

goroutine 4355 [running]:
github.com/barnybug/go-cast/controllers.(*ReceiverStatus).GetSessionByAppId(0x0, 0x42a8c6, 0x8, 0x42a8c6)
 /Users/takuma.morikawa/go/pkg/mod/github.com/barnybug/go-cast@v0.0.0-20190910160619-d2aa97f56d4e/controllers/receiver.go:118 +0x14
github.com/barnybug/go-cast.(*Client).launchApp(0x1c91c7c, 0x4cb1a8, 0x187801c, 0x42a8c6, 0x8, 0x197fe80, 0x1c91bb0, 0x1, 0x0)
 /Users/takuma.morikawa/go/pkg/mod/github.com/barnybug/go-cast@v0.0.0-20190910160619-d2aa97f56d4e/client.go:145 +0x134
github.com/barnybug/go-cast.(*Client).launchMediaApp(...)
 /Users/takuma.morikawa/go/pkg/mod/github.com/barnybug/go-cast@v0.0.0-20190910160619-d2aa97f56d4e/client.go:155
github.com/barnybug/go-cast.(*Client).Media(0x1c91c7c, 0x4cb1a8, 0x187801c, 0x4c9bf0, 0x7457d8, 0x1a2dc80)
 /Users/takuma.morikawa/go/pkg/mod/github.com/barnybug/go-cast@v0.0.0-20190910160619-d2aa97f56d4e/client.go:180 +0x68
github.com/evalphobia/google-home-client-go/googlehome.(*Client).Play(0x1a2cb10, 0x1ae8240, 0x223, 0x0, 0x0)
 /Users/takuma.morikawa/go/pkg/mod/github.com/evalphobia/google-home-client-go@v0.1.1/googlehome/client.go:92 +0x174
github.com/evalphobia/google-home-client-go/googlehome.(*Client).Notify(0x1a2cb10, 0x19e2140, 0x96, 0x0, 0x0, 0x0, 0x1a701e0, 0x11)
 /Users/takuma.morikawa/go/pkg/mod/github.com/evalphobia/google-home-client-go@v0.1.1/googlehome/client.go:79 +0xa4
github.com/eure/bobo-googlehome/googlehome.castPlayTask.Run(...)
```

To handle it, this PR adds `recover()` on each method.